### PR TITLE
Simplify Onboarding

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,43 @@
+# let's start four terminals in two tab groups
+tasks:
+  - name: db
+    init: >
+      mkdir -p /workspace/mongodb &&
+      mkdir -p /workspace/data &&
+      wget -qO- https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.6.13.tgz | tar xzaf - -C /workspace/mongodb --strip-components=1
+    command: >
+      /workspace/mongodb/bin/mongod --dbpath /workspace/data
+  - name: server
+    before: >
+      cd ./server
+    init: >
+      yarn install --mutex network
+    command: >
+      yarn watch
+
+  - name: client gen:types:watch
+    openMode: split-right #open a new tab group
+    before: >
+      cd ./client
+    command: >
+      yarn gen:types:watch
+  - name: client
+    before: >
+      cd ./client
+    init: >
+      cp ./src/config/example.env.json ./src/config/development.env.json &&
+      yarn install --mutex network
+    command: >
+      sed -i 's@http://127.0.0.1:4000@'"$(gp url 4000)"'@g' ./src/config/development.env.json &&
+      gp open ./src/config/development.env.json &&
+      yarn start
+
+ports:
+  - port: 31997 # yarn mutex
+    onOpen: ignore
+  - port: 27017 # mongo
+    onOpen: ignore
+  - port: 4000 # server
+    onOpen: ignore
+  - port: 3000 # server
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ yarn start
 yarn gen:types:watch
 ```
 
+You can start coding right away using Gitpod, a free online dev environment.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/TrillCyborg/fullstack)
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Hey 👋 
this PR adds support for Gitpod, a free online dev environment that we'e built to simplify contributions and generally working on GitHub projects. It allows anyone to get a ready-to-code dev environment for any branch, issue and pull request with a single click (resp. by prefixing the GitHub URL with `gitpod.io/#`).

<img width="1765" alt="Screenshot 2019-06-20 at 15 55 17" src="https://user-images.githubusercontent.com/372735/59854868-02902000-9374-11e9-9971-c28f7df2369f.png">

You can try it out on my branch

https://gitpod.io/#https://github.com/svenefftinge/fullstack

The workspace is configured so that four processes are started automatically in distinct terminals
 - mongodb
 - server
 - client (`yarn gen:types:watch`)
 - client (`yarn start`)

I also made it open the website in the preview automatically once it gets served. You can reach the graphql interface (port 4000) as well. See the `ports` tab on the bottom.

Also, I made it open the `development.env.json` on startup and update the server URL so that people see they have to insert more tokens.

It seems to work well, but of course you might have better ideas how a perfect dev environment for fullstack should look like. Let me know whether you like it and how I should improve further. Also, I'm happy to support this in future, too.

P.S.: Gitpod unleashed its full potential when you install the [GitHub app](https://github.com/marketplace/gitpod-io). It will prebuild all branches (incl. PRs) so when you open a workspace you don't have to wait for the build. The app is also capable of adding buttons to issues. For instance, you can configure it to add a button to all `first timer welcome` issues. I made my fork use a prebuild, which is why the yarn install has already happened when you open it. Without prebuilds the `init` part in tasks will be executed everytime.