### PR TITLE
Add Dockerfile for server

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,21 +1,17 @@
-# Use an official Python runtime as a parent image
+# Use an official Node runtime as a parent image
 FROM node:12.6.0
 
-ENV SERVER_PORT=4000
-ENV DB_NAME=propbet
-ENV ACCOUNTS_SECRET=secret
-ENV MONGO_HOST=0.0.0.0
-
 # Set the working directory to /
-WORKDIR /
+WORKDIR /usr/src/app
 
-# Copy the current directory contents into the container at /app
-COPY . /
+# Copy the current directory contents into the container at /user/src/app
+COPY . .
 
-# Install any needed packages specified in requirements.txt
+# Install dependencies
 RUN yarn
 
+# Expose port for external use
 EXPOSE 4000
 
-# Run app.py when the container launches
+# Run server
 CMD ["yarn", "watch"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,21 @@
+# Use an official Python runtime as a parent image
+FROM node:12.6.0
+
+ENV SERVER_PORT=4000
+ENV DB_NAME=propbet
+ENV ACCOUNTS_SECRET=secret
+ENV MONGO_HOST=0.0.0.0
+
+# Set the working directory to /
+WORKDIR /
+
+# Copy the current directory contents into the container at /app
+COPY . /
+
+# Install any needed packages specified in requirements.txt
+RUN yarn
+
+EXPOSE 4000
+
+# Run app.py when the container launches
+CMD ["yarn", "watch"]


### PR DESCRIPTION
First of all, thank you for sharing this repo with the world and allowing people to learn from it! I have learned a few things myself.

I thought it would be useful to add a `Dockerfile` for the server to be able to run it in a docker environment. I forked this repo and created a `Dockerfile` for both `client` and `server`, and a `docker-compose.yml` to hook them together along with supplying a `mongodb` service. I figured it would be worth adding them in steps, unless you believe they could all be added together.

Once both `client` and `server` have Dockerfiles, and a `docker-compose.yml` file exists, you'll be able to start the entire app up with just a `docker-compose up` rather than starting them up separately. I suppose you'll also need to set up the config stuff too as you've already outlined.